### PR TITLE
Make sure `now` is always UTC

### DIFF
--- a/mongodb-ebs-snapshot
+++ b/mongodb-ebs-snapshot
@@ -68,7 +68,7 @@ def generate_dt_list(start, end, delta):
         curr += delta
     return res
 
-now = datetime.now()
+now = datetime.utcnow()
 
 # Logging
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)


### PR DESCRIPTION
AWS timestamps are all in UTC timezome so if host the script is running on is in a timezone other than UTC, all the hourly snapshots may get deleted.